### PR TITLE
Fixed NPE when using an invalid Network target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@
 hs_err_pid*
 
 **/savedata
+*.dat

--- a/byteBreak/Shell.java
+++ b/byteBreak/Shell.java
@@ -12,6 +12,7 @@ public class Shell
 {
    Network internet;
    int sess = -1;
+   PC pc = null;
    
    public Shell(Network newInternet)
    {
@@ -20,10 +21,12 @@ public class Shell
    
    public void start(String target)
    {
-      PC pc = internet.get(target);
-      pc.updateConfig();
-      if(login(pc))
-         input(pc);
+      try {
+         pc = internet.get(target);
+         pc.updateConfig();
+         if(login(pc))
+            input(pc);
+      } catch (NullPointerException t) {}
    }
    
    public boolean login(PC pc)


### PR DESCRIPTION
This pull request fixes a `NullPointerException` when trying to connect to an invalid network target using the `ssh` command.